### PR TITLE
Fixing failing tests

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -122,7 +122,7 @@ describe("shouldSendSameSiteNone with mutiple cookies", () => {
         const response = await supertest(app)
           .get("/")
           .set("User-Agent", negativeTestCases[i]);
-        const expected = ["foo=bar; Path=/;,koo=mar; Path=/;"];
+        const expected = ["foo=bar; Path=/;", "koo=mar; Path=/;"];
         expect(response.header["set-cookie"]).toEqual(expected);
         expect(response.text).toEqual("ok");
         done();
@@ -137,7 +137,7 @@ describe("shouldSendSameSiteNone with mutiple cookies", () => {
           .get("/")
           .set("User-Agent", positiveTestCases[i]);
         const expected = [
-          "foo=bar; Path=/; SameSite=None,koo=mar; Path=/; SameSite=None"
+          "foo=bar; Path=/; SameSite=None", "koo=mar; Path=/; SameSite=None"
         ];
         expect(response.header["set-cookie"]).toEqual(expected);
         expect(response.text).toEqual("ok");


### PR DESCRIPTION
running `npm run test` on master results in the following

[failingTests.txt](https://github.com/linsight/should-send-same-site-none/files/4160431/failingTests.txt)

I've added some missing quotes to separate the expected cases.
