### PR TITLE
Monkeypatch res.writeHead instead of res.end

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ var shouldSendSameSiteNone = function(req, res, next) {
     var isCompatible = isSameSiteNoneCompatible(ua);
     var cookies = res.get("Set-Cookie");
     var removeSameSiteNone = function(str) {
-      return str.replace(/ SameSite=None;?/g, "");
+      return str.replace(/;\s*SameSite\s*=\s*None\s*(?=;|$)/ig, "");
     };
     if (!isCompatible && cookies) {
       if (Array.isArray(cookies)) {

--- a/index.js
+++ b/index.js
@@ -112,8 +112,8 @@ function isUcBrowserVersionAtLeast(major, minor, build, useragent) {
 }
 
 var shouldSendSameSiteNone = function(req, res, next) {
-  var end = res.end;
-  res.end = function() {
+  var writeHead = res.writeHead;
+  res.writeHead = function() {
     var ua = req.get("user-agent");
     var isCompatible = isSameSiteNoneCompatible(ua);
     var cookies = res.get("Set-Cookie");
@@ -129,7 +129,7 @@ var shouldSendSameSiteNone = function(req, res, next) {
       res.set("Set-Cookie", cookies);
     }
 
-    end.apply(this, arguments);
+    writeHead.apply(this, arguments);
   };
   next();
 };

--- a/index.test.js
+++ b/index.test.js
@@ -104,6 +104,7 @@ describe("shouldSendSameSiteNone with mutiple cookies", () => {
     app = new express();
     app.use(shouldSendSameSiteNone);
     app.get("/", (req, res, next) => {
+      res.set("Set-Cookie", "a=b;samesite = none ;secure");
       res.cookie("foo", "bar", { sameSite: "none" });
       res.cookie("koo", "mar", { sameSite: "none" });
       res.send("ok");
@@ -122,7 +123,7 @@ describe("shouldSendSameSiteNone with mutiple cookies", () => {
         const response = await supertest(app)
           .get("/")
           .set("User-Agent", negativeTestCases[i]);
-        const expected = ["foo=bar; Path=/;", "koo=mar; Path=/;"];
+        const expected = ["a=b;secure", "foo=bar; Path=/", "koo=mar; Path=/"];
         expect(response.header["set-cookie"]).toEqual(expected);
         expect(response.text).toEqual("ok");
         done();
@@ -137,7 +138,9 @@ describe("shouldSendSameSiteNone with mutiple cookies", () => {
           .get("/")
           .set("User-Agent", positiveTestCases[i]);
         const expected = [
-          "foo=bar; Path=/; SameSite=None", "koo=mar; Path=/; SameSite=None"
+          "a=b;samesite = none ;secure",
+          "foo=bar; Path=/; SameSite=None",
+          "koo=mar; Path=/; SameSite=None"
         ];
         expect(response.header["set-cookie"]).toEqual(expected);
         expect(response.text).toEqual("ok");
@@ -170,7 +173,7 @@ describe("shouldSendSameSiteNone with single cookies", () => {
         const response = await supertest(app)
           .get("/")
           .set("User-Agent", negativeTestCases[i]);
-        const expected = ["foo=bar; Path=/;"];
+        const expected = ["foo=bar; Path=/"];
         expect(response.header["set-cookie"]).toEqual(expected);
         expect(response.text).toEqual("ok");
         done();


### PR DESCRIPTION
The middleware would fail if res.write() or res.writeHead() are called, with the error:

Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client

This change moves the logic to the last valid moment to make header changes.
However, note that the writeHead method takes an optional `headers` argument,
that this code will not fix up. If you want to address that edge case, you could add
apply headers argument to the request first, then don't send the headers through
to writeHead().

---

I also tweaked the regex so that:

- Both `SameSite` and `None` should be matched case-insensitively.
  (The `cookies` package writes it as all lowercase and that is
  valid according to the relevant standards.)
- Whitespace is allowed between all tokens.
- Cookie headers are not allowed to end with a semicolon (RFC6265
  section 4.1.1), the new pattern avoids that.
